### PR TITLE
Remove dot from scanned site

### DIFF
--- a/scanner/scanner.go
+++ b/scanner/scanner.go
@@ -10,13 +10,13 @@ import (
 	"sync"
 
 	metrics "github.com/bmc-toolbox/gin-go-metrics"
-
-	"github.com/bmc-toolbox/dora/model"
-	"github.com/bmc-toolbox/dora/storage"
 	"github.com/jinzhu/gorm"
 	"github.com/nats-io/go-nats"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/viper"
+
+	"github.com/bmc-toolbox/dora/model"
+	"github.com/bmc-toolbox/dora/storage"
 )
 
 // Kea is the main entry for parsing the kea config file
@@ -85,10 +85,14 @@ func LoadSubnetsFromKea(content []byte) (subnets []*ToScan) {
 						log.WithFields(log.Fields{"operation": "subnet parsing"}).Warn(err)
 						continue
 					}
+
+					site := strings.TrimSuffix(option.Data, keaDomainNameSuffix)
+					site = strings.Trim(site, ".")
 					toScan := &ToScan{
 						CIDR: ipv4Net.String(),
-						Site: strings.TrimSuffix(option.Data, keaDomainNameSuffix),
+						Site: site,
 					}
+
 					subnets = append(subnets, toScan)
 				}
 			}


### PR DESCRIPTION
When scanning the sites dora persists all port states and uses a `site`
string as identifier.  E.g. given the kea domain suffix of
`lom.example.com` and a subdomain of `mysite.lom.example.com` then
`mysite` is the site.  Due to an oversight in strings operation the site
became `mysite.` with trailing dot.  That causes unmatched expectations
when specifiying a `site` on the command line without the trailing dot.

At Booking there are stale records w/o the trailing dot that were never
deleted and cause redundant and dead-end scans.

This fixes the string manipulation, i.e. removes the trailing dot.  The
idea is to let dora have at least one full run and then delete all
records with trailing dot from the database manually:

```sql
delete from scanned_port where site like '%.';
```